### PR TITLE
Fixing generate_identifier and generate_identifier_ss

### DIFF
--- a/operations/_scripts/generate/generate_identifier.sh
+++ b/operations/_scripts/generate/generate_identifier.sh
@@ -88,6 +88,7 @@ if [ -z "$AWS_RESOURCE_IDENTIFIER" ]; then
   GITHUB_IDENTIFIER="$(shorten_identifier ${GITHUB_IDENTIFIER} $1)"
 else
   GITHUB_IDENTIFIER="$AWS_RESOURCE_IDENTIFIER"
+  GITHUB_IDENTIFIER="$(shorten_identifier ${GITHUB_IDENTIFIER} $1)"
 fi
 
 GITHUB_IDENTIFIER=$(echo $GITHUB_IDENTIFIER | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr '/' '-')


### PR DESCRIPTION
- When setting a specific aws_resource_identifier, we were not checking and/or reducing it's length. 
This fix will allow us to set the aws_resource_identifier to any length without breaking anything (as it didn't work before).

Problem was that if we set that to the value being used in an action, we didn't accept it because of it's length. Now we shorten it as we do every time in an automated way.