### PR TITLE
Fix proxy port number in aws_db_proxy

### DIFF
--- a/operations/deployment/terraform/modules/aws/db_proxy/aws_db_proxy.tf
+++ b/operations/deployment/terraform/modules/aws/db_proxy/aws_db_proxy.tf
@@ -20,7 +20,7 @@ locals {
   auth_selected = one(compact([for key, value in local.auth_mapping : strcontains(lower(local.db_engine), key) ? value : ""]))
   ###
   db_engine         = var.aws_db_proxy_cluster ? data.aws_rds_cluster.db[0].engine : data.aws_db_instance.db[0].engine
-  db_port           = var.aws_db_proxy_cluster ? tonumber(data.aws_rds_cluster.db[0].port) : tonumber(data.aws_db_instance.db[0].db_instance_port)
+  db_port           = var.aws_db_proxy_cluster ? tonumber(data.aws_rds_cluster.db[0].port) : tonumber(data.aws_db_instance.db[0].port)
   db_security_group = var.aws_db_proxy_cluster ? data.aws_rds_cluster.db[0].vpc_security_group_ids : data.aws_db_instance.db[0].vpc_security_groups
 }
 


### PR DESCRIPTION
It's been a while since I looked at this, but from what I could tell, the name was incorrect here.

Tested in https://github.com/bitovi/bitovi-managed-n8n/blob/a6e9477ce02848b4ab7af236f9d0f9d44bec19a6/.github/workflows/deploy-rds.yaml#L15


