### PR TITLE
ECS DNS skip recreate fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ operations/deployment/terraform/inventory.yaml
 
 *.pem
 .vscode/
-#operations/deployment/terraform/modules/aws/lb**
-**/lb**

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ operations/deployment/terraform/inventory.yaml
 
 *.pem
 .vscode/
+#operations/deployment/terraform/modules/aws/lb**
+**/lb**

--- a/action.yaml
+++ b/action.yaml
@@ -1438,8 +1438,8 @@ runs:
         AWS_ECS_ENABLE: ${{ inputs.aws_ecs_enable }}
         AWS_ECS_SERVICE_NAME: ${{ inputs.aws_ecs_service_name }}
         AWS_ECS_CLUSTER_NAME: ${{ inputs.aws_ecs_cluster_name }}
-        AWS_ECS_SERVICE_LAUNCH_TYPE : ${{ inputs.aws_ecs_service_launch_type }}
-        AWS_ECS_TASK_TYPE : ${{ inputs.aws_ecs_task_type }}
+        AWS_ECS_SERVICE_LAUNCH_TYPE: ${{ inputs.aws_ecs_service_launch_type }}
+        AWS_ECS_TASK_TYPE: ${{ inputs.aws_ecs_task_type }}
         AWS_ECS_TASK_NAME: ${{ inputs.aws_ecs_task_name }}
         AWS_ECS_TASK_IGNORE_DEFINITION: ${{ inputs.aws_ecs_task_ignore_definition }}
         AWS_ECS_TASK_EXECUTION_ROLE: ${{ inputs.aws_ecs_task_execution_role }}
@@ -1448,7 +1448,7 @@ runs:
         AWS_ECS_TASK_CPU: ${{ inputs.aws_ecs_task_cpu }}
         AWS_ECS_TASK_MEM: ${{ inputs.aws_ecs_task_mem }}
         AWS_ECS_CONTAINER_CPU: ${{ inputs.aws_ecs_container_cpu }}
-        AWS_ECS_CONTAINER_MEM: ${{ inputs.aws_ecs_container_cpu }}
+        AWS_ECS_CONTAINER_MEM: ${{ inputs.aws_ecs_container_mem }}
         AWS_ECS_NODE_COUNT: ${{ inputs.aws_ecs_node_count }}
         AWS_ECS_APP_IMAGE: ${{ inputs.aws_ecs_app_image }}
         AWS_ECS_SECURITY_GROUP_NAME: ${{ inputs.aws_ecs_security_group_name }}
@@ -1456,17 +1456,17 @@ runs:
         AWS_ECS_CONTAINER_PORT: ${{ inputs.aws_ecs_container_port }}
         AWS_ECS_LB_PORT: ${{ inputs.aws_ecs_lb_port }}
         AWS_ECS_LB_REDIRECT_ENABLE: ${{ inputs.aws_ecs_lb_redirect_enable }}
-        AWS_ECS_LB_CONTAINER_PATH : ${{ inputs.aws_ecs_lb_container_path }}
+        AWS_ECS_LB_CONTAINER_PATH: ${{ inputs.aws_ecs_lb_container_path }}
         AWS_ECS_LB_SSL_POLICY: ${{ inputs.aws_ecs_lb_ssl_policy }}
         AWS_ECS_AUTOSCALING_ENABLE: ${{ inputs.aws_ecs_autoscaling_enable }}
         AWS_ECS_AUTOSCALING_MAX_NODES: ${{ inputs.aws_ecs_autoscaling_max_nodes }}
         AWS_ECS_AUTOSCALING_MIN_NODES: ${{ inputs.aws_ecs_autoscaling_min_nodes }}
         AWS_ECS_AUTOSCALING_MAX_MEM: ${{ inputs.aws_ecs_autoscaling_max_mem }}
-        AWS_ECS_AUTOSCALING_MIN_MEM: ${{ inputs.aws_ecs_autoscaling_max_cpu }}
-        AWS_ECS_CLOUDWATCH_ENABLE : ${{ inputs.aws_ecs_cloudwatch_enable }}
-        AWS_ECS_CLOUDWATCH_LG_NAME : ${{ inputs.aws_ecs_cloudwatch_lg_name }}
-        AWS_ECS_CLOUDWATCH_SKIP_DESTROY : ${{ inputs.aws_ecs_cloudwatch_skip_destroy }}
-        AWS_ECS_CLOUDWATCH_RETENTION_DAYS : ${{ inputs.aws_ecs_cloudwatch_retention_days }}
+        AWS_ECS_AUTOSCALING_MAX_CPU: ${{ inputs.aws_ecs_autoscaling_max_cpu }}
+        AWS_ECS_CLOUDWATCH_ENABLE: ${{ inputs.aws_ecs_cloudwatch_enable }}
+        AWS_ECS_CLOUDWATCH_LG_NAME: ${{ inputs.aws_ecs_cloudwatch_lg_name }}
+        AWS_ECS_CLOUDWATCH_SKIP_DESTROY: ${{ inputs.aws_ecs_cloudwatch_skip_destroy }}
+        AWS_ECS_CLOUDWATCH_RETENTION_DAYS: ${{ inputs.aws_ecs_cloudwatch_retention_days }}
         AWS_ECS_ADDITIONAL_TAGS: ${{ inputs.aws_ecs_additional_tags }}
        
         # ECR

--- a/operations/deployment/terraform/aws/bitovi_main.tf
+++ b/operations/deployment/terraform/aws/bitovi_main.tf
@@ -519,13 +519,13 @@ module "aws_route53_ecs" {
   aws_r53_root_domain_deploy    = var.aws_r53_root_domain_deploy
   aws_r53_enable_cert           = var.aws_r53_enable_cert
   # ELB
-  aws_elb_dns_name              = try(module.aws_ecs[0].load_balancer_dns,"")
-  aws_elb_zone_id               = try(module.aws_ecs[0].load_balancer_zone_id,"")
+  aws_elb_dns_name              = module.aws_ecs[0].load_balancer_dns
+  aws_elb_zone_id               = module.aws_ecs[0].load_balancer_zone_id
   # Certs
   aws_certificates_selected_arn = var.aws_r53_enable_cert && var.aws_r53_domain_name != "" ? module.aws_certificates[0].selected_arn : ""
   # Others
   fqdn_provided                 = local.fqdn_provided
-  depends_on = [ module.aws_certificates,module.aws_ecs ]
+  depends_on = [ module.aws_certificates ]
   providers = {
     aws = aws.r53
   }

--- a/operations/deployment/terraform/modules/aws/ecs/aws_ecs.tf
+++ b/operations/deployment/terraform/modules/aws/ecs/aws_ecs.tf
@@ -111,11 +111,6 @@ resource "aws_ecs_task_definition" "aws_ecs_task_ignore_definition" {
   }
 }
 
-locals {
-  tasks_arns  = concat(aws_ecs_task_definition.ecs_task[*].arn,aws_ecs_task_definition.ecs_task_from_json[*].arn,aws_ecs_task_definition.aws_ecs_task_ignore_definition[*].arn)
-  tasks_count = var.aws_ecs_task_ignore_definition ? 1 : length(local.aws_ecs_app_image) + length(local.aws_ecs_task_json_definition_file)
-}
-
 resource "aws_ecs_service" "ecs_service" {
   count            = var.aws_ecs_task_ignore_definition ? 0 : local.tasks_count
   name             = var.aws_ecs_service_name != "" ? "${var.aws_ecs_service_name}${count.index}" : "${var.aws_resource_identifier}-${count.index}-service"


### PR DESCRIPTION
While running the ECS action, DNS record gets recreated on each run. 
Removed some dependencies that avoid that from happening.

Fixes in indentation, wrongly used variables, and better code formatting. 