### PR TITLE
Bugfix certificate and URL Output issue

### DIFF
--- a/operations/deployment/terraform/aws/bitovi_main.tf
+++ b/operations/deployment/terraform/aws/bitovi_main.tf
@@ -820,10 +820,10 @@ locals {
   alb_url              = try(module.aws_lb[0].aws_alb_dns_name, null) != null ? "${local.protocol}${module.aws_lb[0].aws_alb_dns_name}" : null
 
   vm_url_candidates = [
-    try(module.aws_route53[0].vm_url, null),
+    try(try(module.aws_route53[0].vm_url, null),
     local.alb_url,
     local.elb_url,
-    local.ec2_endpoint
+    local.ec2_endpoint,null)
   ]
   vm_url_first_nonempty = [for url in local.vm_url_candidates : url if url != null && url != ""][0]
 }

--- a/operations/deployment/terraform/aws/bitovi_main.tf
+++ b/operations/deployment/terraform/aws/bitovi_main.tf
@@ -825,8 +825,13 @@ locals {
       local.elb_url,
     local.ec2_endpoint, null)
   ]
-  vm_url_first_nonempty = length(local.vm_url_candidates) > 0 ?  [for url in local.vm_url_candidates : url if url != null && url != ""][0] : null
+  vm_url_first_nonempty = (
+    length([for url in local.vm_url_candidates : url if url != null && url != ""]) > 0
+      ? [for url in local.vm_url_candidates : url if url != null && url != ""][0]
+      : null
+  )
 }
+
 # VPC
 output "aws_vpc_id" {
   value = module.vpc.aws_selected_vpc_id

--- a/operations/deployment/terraform/aws/bitovi_main.tf
+++ b/operations/deployment/terraform/aws/bitovi_main.tf
@@ -820,11 +820,13 @@ locals {
   alb_url              = try(module.aws_lb[0].aws_alb_dns_name, null) != null ? "${local.protocol}${module.aws_lb[0].aws_alb_dns_name}" : null
 
   vm_url_candidates = [
-    try(module.aws_route53[0].vm_url, local.alb_url, local.elb_url, local.ec2_endpoint, null)
+    try(try(module.aws_route53[0].vm_url, null),
+      local.alb_url,
+      local.elb_url,
+    local.ec2_endpoint, null)
   ]
-  vm_url_first_nonempty = length(local.vm_url_candidates) > 0 ? [for url in local.vm_url_candidates : url if url != null && url != ""][0] : null
+  vm_url_first_nonempty = length(local.vm_url_candidates) > 0 ?  [for url in local.vm_url_candidates : url if url != null && url != ""][0] : null
 }
-
 # VPC
 output "aws_vpc_id" {
   value = module.vpc.aws_selected_vpc_id

--- a/operations/deployment/terraform/aws/bitovi_main.tf
+++ b/operations/deployment/terraform/aws/bitovi_main.tf
@@ -825,8 +825,9 @@ locals {
       local.elb_url,
     local.ec2_endpoint, null)
   ]
-  vm_url_first_nonempty = [for url in local.vm_url_candidates : url if url != null && url != ""][0]
+  vm_url_first_nonempty = length(local.vm_url_candidates) > 0 ? [for url in local.vm_url_candidates : url if url != null && url != ""][0] : null
 }
+
 # VPC
 output "aws_vpc_id" {
   value = module.vpc.aws_selected_vpc_id

--- a/operations/deployment/terraform/aws/bitovi_main.tf
+++ b/operations/deployment/terraform/aws/bitovi_main.tf
@@ -816,12 +816,13 @@ locals {
   ec2_public_endpoint  = var.aws_ec2_instance_create ? (module.ec2[0].instance_public_dns != null ? module.ec2[0].instance_public_dns : module.ec2[0].instance_public_ip) : null
   ec2_private_endpoint = var.aws_ec2_instance_create ? (module.ec2[0].instance_private_dns != null ? module.ec2[0].instance_private_dns : module.ec2[0].instance_private_ip) : null
   ec2_endpoint         = var.aws_ec2_instance_create ? (local.ec2_public_endpoint != null ? "${local.protocol}${local.ec2_public_endpoint}" : "${local.protocol}${local.ec2_private_endpoint}") : null
-  elb_url              = try(module.aws_elb[0].aws_elb_dns_name, null) != null &&  try(module.aws_elb[0].aws_elb_dns_name, null) != "" ? "${local.protocol}${module.aws_elb[0].aws_elb_dns_name}" : null
-  alb_url              = try(module.aws_lb[0].aws_alb_dns_name, null) != null && try(module.aws_lb[0].aws_alb_dns_name, null) != "" ? "${local.protocol}${module.aws_lb[0].aws_alb_dns_name}" : null
+  elb_url              = try(module.aws_elb[0].aws_elb_dns_name, null) != null ? "${local.protocol}${module.aws_elb[0].aws_elb_dns_name}" : null
+  alb_url              = try(module.aws_lb[0].aws_alb_dns_name, null) != null ? "${local.protocol}${module.aws_lb[0].aws_alb_dns_name}" : null
 
-  vm_url = [
+  vm_url_candidates = [
     try(module.aws_route53[0].vm_url, local.alb_url, local.elb_url, local.ec2_endpoint, null)
   ]
+  vm_url_first_nonempty = length(local.vm_url_candidates) > 0 ? [for url in local.vm_url_candidates : url if url != null && url != ""][0] : null
 }
 
 # VPC
@@ -881,7 +882,7 @@ output "application_public_dns" {
 
 output "vm_url" {
   description = "Will print the best available URL for the VM, ALB, ELB or EC2 instance"
-  value       = try(local.vm_url, null)
+  value       = try(local.vm_url_first_nonempty, null)
 }
 
 # EFS

--- a/operations/deployment/terraform/aws/bitovi_main.tf
+++ b/operations/deployment/terraform/aws/bitovi_main.tf
@@ -821,9 +821,9 @@ locals {
 
   vm_url_candidates = [
     try(try(module.aws_route53[0].vm_url, null),
-    local.alb_url,
-    local.elb_url,
-    local.ec2_endpoint,null)
+      local.alb_url,
+      local.elb_url,
+    local.ec2_endpoint, null)
   ]
   vm_url_first_nonempty = [for url in local.vm_url_candidates : url if url != null && url != ""][0]
 }
@@ -883,7 +883,8 @@ output "application_public_dns" {
 }
 
 output "vm_url" {
-  value = local.vm_url_first_nonempty
+  description = "Will print the best available URL for the VM, ALB, ELB or EC2 instance"
+  value       = try(local.vm_url_first_nonempty, null)
 }
 
 # EFS

--- a/operations/deployment/terraform/aws/bitovi_main.tf
+++ b/operations/deployment/terraform/aws/bitovi_main.tf
@@ -827,8 +827,8 @@ locals {
   ]
   vm_url_first_nonempty = (
     length([for url in local.vm_url_candidates : url if url != null && url != ""]) > 0
-      ? [for url in local.vm_url_candidates : url if url != null && url != ""][0]
-      : null
+    ? [for url in local.vm_url_candidates : url if url != null && url != ""][0]
+    : null
   )
 }
 

--- a/operations/deployment/terraform/modules/aws/certificates/aws_certificates.tf
+++ b/operations/deployment/terraform/modules/aws/certificates/aws_certificates.tf
@@ -10,7 +10,7 @@ data "aws_acm_certificate" "issued" {
     "wildcard" = "*.${var.aws_r53_domain_name}",
     "sub"      = "${var.aws_r53_sub_domain_name}.${var.aws_r53_domain_name}"
   } : {}
-  domain = each.value
+  domain = var.aws_r53_domain_name
 }
 
 # This block will create and validate the root domain and www cert


### PR DESCRIPTION
- Certificate issue - during certificate improvements, a bug was introduced that looked up for more certificates than needed.
- VM_URL output fix - During ALB introduction for EC2, we provided a URL based on the first non-empty value. As a result, if none was provided (like in ECS), a breaking error was shown.